### PR TITLE
mongodb_instance: remove mongodb_type, update recipes

### DIFF
--- a/definitions/mongodb.rb
+++ b/definitions/mongodb.rb
@@ -20,18 +20,12 @@
 #
 
 define :mongodb_instance,
-       :mongodb_type  => 'mongod',
        :action        => [:enable, :start],
        :logpath       => '/var/log/mongodb/mongodb.log',
        :dbpath        => '/data',
        :configservers => [],
        :replicaset    => nil,
        :notifies      => [] do
-
-  # TODO: this is the only remain use of params[:mongodb_type], is it still needed?
-  unless %w(mongod shard configserver mongos).include?(params[:mongodb_type])
-    fail ArgumentError, ":mongodb_type must be 'mongod', 'shard', 'configserver' or 'mongos'; was #{params[:mongodb_type].inspect}"
-  end
 
   # Make changes to node['mongodb']['config'] before copying to new_resource. Chef 11 appears to resolve the attributes
   # with precedence while Chef 10 copies to not (TBD: find documentation to support observed behavior).

--- a/recipes/configserver.rb
+++ b/recipes/configserver.rb
@@ -19,6 +19,7 @@
 # limitations under the License.
 #
 
+# ensure these are stored by using node.set, not merely node.default
 node.set['mongodb']['is_configserver'] = true
 node.set['mongodb']['cluster_name'] = node['mongodb']['cluster_name']
 node.set['mongodb']['shard_name'] = node['mongodb']['shard_name']
@@ -29,10 +30,10 @@ include_recipe 'mongodb::install'
 # http://docs.mongodb.org/manual/reference/configuration-options/#sharded-cluster-options
 # we still explicitly set the port and small files.
 mongodb_instance node['mongodb']['instance_name'] do
-  mongodb_type 'configserver'
-  port         node['mongodb']['config']['port']
-  logpath      node['mongodb']['config']['logpath']
-  dbpath       node['mongodb']['config']['dbpath']
-  enable_rest  node['mongodb']['config']['rest']
-  smallfiles   node['mongodb']['config']['smallfiles']
+  is_configserver  true
+  cluster_name     node['mongodb']['cluster_name']
+  shard_name       node['mongodb']['shard_name']
+  port             node['mongodb']['config']['port']
+  logpath          node['mongodb']['config']['logpath']
+  dbpath           node['mongodb']['config']['dbpath']
 end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -37,12 +37,9 @@ end
 
 if allow_mongodb_instance_run
   mongodb_instance node['mongodb']['instance_name'] do
-    mongodb_type 'mongod'
     bind_ip      node['mongodb']['config']['bind_ip']
     port         node['mongodb']['config']['port']
     logpath      node['mongodb']['config']['logpath']
     dbpath       node['mongodb']['config']['dbpath']
-    enable_rest  node['mongodb']['config']['rest']
-    smallfiles   node['mongodb']['config']['smallfiles']
   end
 end

--- a/recipes/mongos.rb
+++ b/recipes/mongos.rb
@@ -19,6 +19,7 @@
 # limitations under the License.
 #
 
+# ensure these are stored by using node.set, not merely node.default
 node.set['mongodb']['is_mongos'] = true
 node.set['mongodb']['shard_name'] = node['mongodb']['shard_name']
 node.override['mongodb']['instance_name'] = 'mongos'
@@ -51,11 +52,10 @@ if configsrvs.length != 1 && configsrvs.length != 3
 end
 
 mongodb_instance node['mongodb']['instance_name'] do
-  mongodb_type 'mongos'
-  port         node['mongodb']['config']['port']
-  logpath      node['mongodb']['config']['logpath']
-  dbpath       node['mongodb']['config']['dbpath']
-  configservers configsrvs
-  enable_rest  node['mongodb']['config']['rest']
-  smallfiles   node['mongodb']['config']['smallfiles']
+  is_mongos      true
+  shard_name     node['mongodb']['shard_name']
+  port           node['mongodb']['config']['port']
+  logpath        node['mongodb']['config']['logpath']
+  dbpath         node['mongodb']['config']['dbpath']
+  configservers  configsrvs
 end

--- a/recipes/replicaset.rb
+++ b/recipes/replicaset.rb
@@ -17,6 +17,7 @@
 # limitations under the License.
 #
 
+# ensure these are stored by using node.set, not merely node.default
 node.set['mongodb']['is_replicaset'] = true
 node.set['mongodb']['cluster_name'] = node['mongodb']['cluster_name']
 
@@ -33,12 +34,11 @@ end
 
 unless node['mongodb']['is_shard']
   mongodb_instance node['mongodb']['instance_name'] do
-    mongodb_type 'mongod'
+    is_replicaset  true
+    cluster_name  node['mongodb']['cluster_name']
     port         node['mongodb']['config']['port']
     logpath      node['mongodb']['config']['logpath']
     dbpath       node['mongodb']['config']['dbpath']
     replicaset   node
-    enable_rest  node['mongodb']['config']['rest']
-    smallfiles   node['mongodb']['config']['smallfiles']
   end
 end

--- a/recipes/shard.rb
+++ b/recipes/shard.rb
@@ -19,6 +19,7 @@
 # limitations under the License.
 #
 
+# ensure these are stored by using node.set, not merely node.default
 node.set['mongodb']['is_shard'] = true
 node.set['mongodb']['shard_name'] = node['mongodb']['shard_name']
 node.set['mongodb']['is_replicaset'] = node['mongodb']['is_replicaset']
@@ -30,11 +31,12 @@ include_recipe 'mongodb::install'
 # commandline option because right now this only changes the port it's
 # running on, and we are overwriting this port anyway.
 mongodb_instance node['mongodb']['instance_name'] do
-  mongodb_type 'shard'
-  port         node['mongodb']['config']['port']
-  logpath      node['mongodb']['config']['logpath']
-  dbpath       node['mongodb']['config']['dbpath']
-  replicaset   node if node['mongodb']['is_replicaset']
-  enable_rest  node['mongodb']['config']['rest']
-  smallfiles   node['mongodb']['config']['smallfiles']
+  is_shard       true
+  is_replicaset  node['mongodb']['is_replicaset']
+  port           node['mongodb']['config']['port']
+  logpath        node['mongodb']['config']['logpath']
+  dbpath         node['mongodb']['config']['dbpath']
+  shard_name     node['mongodb']['shard_name']
+  cluster_name   node['mongodb']['cluster_name']
+  replicaset     node if node['mongodb']['is_replicaset']
 end


### PR DESCRIPTION
pretty much what it says on the tin.

I added the `mongodb_type` to add a bit of sanity long ago when I was trying to convert `mongodb_instance` to a resource the first (or hundredth?) time. After updating my resourcification branch, I see it's not needed.
