### PR TITLE
Use new recipe instead of deprecated when adding mongodb org

### DIFF
--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -1,5 +1,5 @@
 # install the 10gen repo if necessary
-include_recipe 'mongodb::10gen_repo' if %w(10gen mongodb-org).include?(node['mongodb']['install_method'])
+include_recipe 'mongodb::mongodb_org_repo' if %w(10gen mongodb-org).include?(node['mongodb']['install_method'])
 
 # prevent-install defaults, but don't overwrite
 file node['mongodb']['sysconfig_file'] do


### PR DESCRIPTION
Simply uses the new(ish) mongodb_org_repo and prevents the deprecation notice of the 10gen_repo recipe
