### PR TITLE
Update Berksfile source to point to current url

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -1,3 +1,3 @@
-source "http://api.berkshelf.com"
+source 'https://supermarket.chef.io'
 
 metadata


### PR DESCRIPTION
Moving this PR over from chef-mongodb; make berks able to find upstream cookbooks.
