### PR TITLE
Allow replicaset members to be added by IP instead of FQDN

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Basically all settings defined in the Configuration File Options documentation p
 
 ### Sharding and replication attributes
 
+* `node[:mongodb][:add_by_ip]` - Set to true to add replicaset members by IP instead of FQDN.
 * `node['mongodb']['config']['replSet']` - Define name of replicaset
 * `node[:mongodb][:cluster_name]` - Name of the cluster, all members of the cluster must
     reference to the same name, as this name is used internally to identify all

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -30,6 +30,7 @@ default[:mongodb][:replica_slave_delay] = 0
 default[:mongodb][:replica_priority] = 1
 default[:mongodb][:replica_tags] = {}
 default[:mongodb][:replica_votes] = 1
+default[:mongodb][:add_by_ip] = false
 
 default[:mongodb][:auto_configure][:replicaset] = true
 default[:mongodb][:auto_configure][:sharding] = true

--- a/libraries/mongodb.rb
+++ b/libraries/mongodb.rb
@@ -53,7 +53,12 @@ class Chef::ResourceDefinitionList::MongoDB
     rs_members = []
     rs_options = {}
     members.each_index do |n|
-      host = "#{members[n]['fqdn']}:#{members[n]['mongodb']['config']['port']}"
+      if node['mongodb']['add_by_ip']
+        host = "#{members[n]['ipaddress']}:#{members[n]['mongodb']['config']['port']}"
+      else
+        host = "#{members[n]['fqdn']}:#{members[n]['mongodb']['config']['port']}"
+      end
+
       rs_options[host] = {}
       rs_options[host]['arbiterOnly'] = true if members[n]['mongodb']['replica_arbiter_only']
       rs_options[host]['buildIndexes'] = false unless members[n]['mongodb']['replica_build_indexes']


### PR DESCRIPTION
Small change to allow replicaset members to be referenced by IP. Useful in cases where FQDN is not a value that can be resolved.
