### PR TITLE
replace deprecated recipe

### DIFF
--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -1,5 +1,5 @@
-# install the 10gen repo if necessary
-include_recipe 'mongodb::10gen_repo' if %w(10gen mongodb-org).include?(node['mongodb']['install_method'])
+# install the mongodb_org_repo if necessary
+include_recipe 'mongodb::mongodb_org_repo' if %w(10gen mongodb-org).include?(node['mongodb']['install_method'])
 
 # prevent-install defaults, but don't overwrite
 file node['mongodb']['sysconfig_file'] do


### PR DESCRIPTION
Since the 10gen recipe is deprecated, the cookbook's own recipes should use the new recipe.