### PR TITLE
Bump to 0.17.0 to tag release a new release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,13 @@
-========================
-Chef-MongoDB Cookbook Changelog
-Last-Update: Tue Nov  4 11:48:54 PST 2014
-========================
+# mongodb Cookbook CHANGELOG
 
-Pending 0.16.3 Changes
---------------------------
+## Pending v0.16.3 Changes
+
 * remove old runit dependency
 * fix user/group attribute variables for newer versions of EL and Fedora
 
 
-Version 0.16.2 Release Tue Nov  4 11:48:54 PST 2014
---------------------------
+## v0.16.2 (Release Tue Nov  4 11:48:54 PST 2014)
+
 * start doing even patches = release, odd = dev.
 * removed unmaintained freebsd support file
 * pass `--force-yes` to apt to bypass issue with package/config conflict #305
@@ -22,79 +19,78 @@ Version 0.16.2 Release Tue Nov  4 11:48:54 PST 2014
 * added fixes for installation prereqs, sasl
 * fix systemd usecase for redhat (#352, #350)
 
+## v0.16.1
 
-Version 0.16.1
---------------------------
 * remove old `mms_agent.rb` and `mms-agent.rb` in favor of new mms_*_agent.rb
 * Update mms_*_agent.rb to use template instead of ruby-block, nothing, but call restart
 * DEPRECATE '10gen_repo' for 'mongodb_org_repo' #287
 * node['mongodb']['install_method'] can now be '10gen' (DEPRECATE) or 'mongodb_org'
 * allow `node['mongodb']['config']['logpath'] to be nil for syslog #288
 
-Version 0.16.0
---------------------------
+## v0.16.0
+
 * BREAKING CHANGE - drop support for Ruby < 1.9, Chef < 11
 * cookbook dependency change
- - yum >= 3.0
- - remove <= limit for all other dep
+  * yum >= 3.0
+  * remove <= limit for all other dep
 * update to Berkshelf 3
 * #280 fix install for centos (missing build-essentials)
 
-Version 0.15.2 End of Ruby 1.8, Chef 10 support
----------------------------
+## v0.15.2 End of Ruby 1.8, Chef 10 support
+
 * update test-kitchen for mongos
 * update MMS version
 * update rubocop
 * minor typo fixes
 
-Version 0.15.1
----------------------------
+## v0.15.1
+
 * 'potentially' BREAKING CHANGES, cookbook dependency pinned
- - yum < 3.0
- - runit < 1.5
- - python < 1.4.5
+  * yum < 3.0
+  * runit < 1.5
+  * python < 1.4.5
 * DEPRECATION: explicitly drop support for 'unsupported' platforms
- - must be freebsd, rhel, fedora, debian
+  * must be freebsd, rhel, fedora, debian
 * DEPRECATION: recipe mms-agent.rb/mms_agent.rb
- - see #261 for new-recipes
+  * see #261 for new-recipes
 * use node.set to make sure is_* attributes are available for search
 * 'key_file' -> 'key_file_content'
 * allow pinning for gems, pip packages
 * #261 new mms agent recipe based on new packaging in upstream
 * #256 Allow mms_agent to be run as non-root user
-- replSet is not set automatically
+  * replSet is not set automatically
 
-Version 0.15.0
----------------------------
+## v0.15.0
+
 * DEPRECATION: backward compatability for dbconfig variables in node['mongodb']
- - use node['mongodb']['config'][variable] = value
+  * use node['mongodb']['config'][variable] = value
 
-Version 0.14.10 DEVELOPMENTAL RELEASE
----------------------------
+## v0.14.10 DEVELOPMENTAL RELEASE
+
 * Final 0.14 release
 * move node['mongodb']['config']['configsrv'] auto update to the top
 * Drop using Chef.Version as it is not rc/beta compatible
 * installs gem bson_ext
 
-Version 0.14.8 DEVELOPMENTAL RELEASE
----------------------------
+## v0.14.8 DEVELOPMENTAL RELEASE
+
 * Rubocop (cherry pick of #220)
 
-Version 0.14.7 DEVELOPMENTAL RELEASE
----------------------------
+## v0.14.7 DEVELOPMENTAL RELEASE
+
 * Automatically install bson_ext gem
 * Add check/protection for empty shard
 * Force node['mongodb']['config']['configsrv'] == true when set as configserver
 
-Version 0.14.6 DEVELOPMENTAL RELEASE
----------------------------
+## v0.14.6 DEVELOPMENTAL RELEASE
+
 * try to autoconfigure 'configsrv' from configserver_nodes
 * remove `include 'mongodb::default'` from definition
 * allow chef-run without restarting mongo
 * comment cleanup
 
-Version 0.14.X DEVELOPMENTAL RELEASES
----------------------------
+## v0.14.X DEVELOPMENTAL RELEASES
+
 * Split out install into separate recipe
 * Adds more testing
 * Fixes mms-agent installation/runtime
@@ -103,20 +99,20 @@ Version 0.14.X DEVELOPMENTAL RELEASES
 * patches to fix upstart service
 * patches to configserver install
 
-Version 0.13.2, RELEASED
----------------------------
-add support for chef_gem on newer versions of chef
+## v0.13.2, RELEASED
 
-Version 0.13.1, RELEASED
----------------------------
-Add keyfileSupport
+* add support for chef_gem on newer versions of chef
 
-Version 0.13.0, RELEASED
----------------------------
-Bunch of stuff...
+## v0.13.1, RELEASED
 
-Version 0.1.0
-----------------------------
+* Add keyfileSupport
+
+## v0.13.0, RELEASED
+
+* Bunch of stuff...
+
+## v0.1.0
+
 Initial release of the cookbooks for the chef configuration management system
 developed at edelight GmbH.
 With this first release we publish the mongodb cookbook we use for our systems.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,25 @@
 # mongodb Cookbook CHANGELOG
 
-## Pending v0.16.3 Changes
+## v0.17.0 Changes
+
+* Add ability to use ipaddress instead of fqdn in replicaset
+* fix creating user bug for custom host and port
+* Add a new install method 'none' that doesn't install.
+* Add NUMA support to debian-mongodb upstart script
+* Moved the ulimit commands to the start function
+* fix for bug #348 - broken sharding
+* Get rid of chef_gem
+* Excluded Amazon Linux from using systemctl
+* pessimistically allow 1.X mongo gem
+* add custom repo support
+* Moved the running of the sysconfig_file above the NUMA support
+* replace deprecated recipe
+* bug fix in member_config for having _id > 255
+* User management in replicasets / sharding
+* Force rs.reconfig when there are no old members
+* Packager Options Attribute
+
+## v0.16.3 Changes (release never tagged, rolled into `v0.17.0` release)
 
 * remove old runit dependency
 * fix user/group attribute variables for newer versions of EL and Fedora

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email  'help@sous-chefs.org'
 license           'Apache 2.0'
 description       'Installs and configures mongodb'
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version           '0.16.3'
+version           '0.17.0'
 
 recipe 'mongodb', 'Installs and configures a single node mongodb instance'
 recipe 'mongodb::10gen_repo', 'Adds the 10gen repo to get the latest packages'


### PR DESCRIPTION
This will will most likely be the last release before a major rewrite is completed which will result in a major version bump