### PR TITLE
Introduce min version dependency on build-essential

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -18,7 +18,7 @@ recipe 'sc-mongodb::mms_backup_agent', 'Installs and configures a MongoDB MMS Ba
 depends 'apt', '>= 1.8.2'
 depends 'yum', '>= 3.0'
 depends 'python'
-depends 'build-essential'
+depends 'build-essential', '>= 5.0.0'
 
 %w(ubuntu debian centos redhat amazon).each do |os|
   supports os


### PR DESCRIPTION
avoid issues with older versions of the build-essential cookbook, resulting in: 

`No resource or method named `build_essential' for `Chef::Recipe "install"'`

Fixes #134 