### PR TITLE
Fixed a Chef warning where only_if block on logpath was ambiguous

### DIFF
--- a/definitions/mongodb.rb
+++ b/definitions/mongodb.rb
@@ -165,7 +165,7 @@ define :mongodb_instance,
     mode '0755'
     action :create
     recursive true
-    only_if { new_resource.logpath }
+    not_if { new_resource.logpath.nil? || new_resource.logpath.empty? }
   end
 
   # dbpath dir [make sure it exists]


### PR DESCRIPTION
I created a wrapper cookbook around this one and when I run my ChefSpec tests I get the below warning:

```
[2017-04-24T09:40:52-04:00] WARN: only_if block for directory[/var/log/mongodb] returned "/var/log/mongodb/mongod.log", did you mean to run a command? If so use 'only_if "/var/log/mongodb/mongod.log"' in your code.
```