### PR TITLE
Remove ip to hostname conversion in replica-set function

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email  'help@sous-chefs.org'
 license           'Apache-2.0'
 description       'Installs and configures mongodb'
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version           '1.0.0'
+version           '1.1.0'
 
 recipe 'sc-mongodb', 'Installs and configures a single node mongodb instance'
 recipe 'sc-mongodb::mongos', 'Installs and configures a mongos which can be used in a sharded setup'


### PR DESCRIPTION
When configuring the mongodb replicat set, one of the steps was to
force the usage of `fqdn` address instead of ips in the member
configuration.

This happens to cause erros when you provide the `use_ip_address`
option, that is needed in cases were the machines `fqdn` is not a valid
DNS record, making the replica set members unreachable.

I removed the code that make the conversion, assuming that this is
acctually a bad behaviour for the cookbook.