### PR TITLE
Fix for issue where mongo would not upgrade on debian based systems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 ## Unreleased
 
-## v1.0.1 Changes
-
 - Fixes issue where on debain based systems mongo is not updated if version is increased
 
 ## v1.0.0 Changes (Released 2017-05-23)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## v1.0.1 Changes
+
+- Fixes issue where on debain based systems mongo is not updated if version is increased
+
 ## v1.0.0 Changes (Released 2017-05-23)
 
 *WARNING:* This is a rewrite that contains many backwards incompatable changes.  Many attributes have changed defaults and/or the attribute key itself.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -53,7 +53,7 @@ default['mongodb']['dbconfig_file']['mongod'] = '/etc/mongod.conf'
 default['mongodb']['dbconfig_file']['mongos'] = '/etc/mongos.conf'
 
 default['mongodb']['package_name'] = 'mongodb'
-default['mongodb']['package_version'] = '3.2.10'
+default['mongodb']['package_version'] = '3.2.18'
 
 default['mongodb']['default_init_name'] = 'mongod'
 default['mongodb']['instance_name']['mongod'] = 'mongod'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email  'help@sous-chefs.org'
 license           'Apache-2.0'
 description       'Installs and configures mongodb'
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version           '1.0.0'
+version           '1.0.1'
 
 recipe 'sc-mongodb', 'Installs and configures a single node mongodb instance'
 recipe 'sc-mongodb::mongos', 'Installs and configures a mongos which can be used in a sharded setup'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email  'help@sous-chefs.org'
 license           'Apache-2.0'
 description       'Installs and configures mongodb'
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version           '1.0.1'
+version           '1.0.0'
 
 recipe 'sc-mongodb', 'Installs and configures a single node mongodb instance'
 recipe 'sc-mongodb::mongos', 'Installs and configures a mongos which can be used in a sharded setup'

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -120,28 +120,14 @@ end
 
 # Change needed so that updates work properly on debian based systems
 if node['platform_family'] == 'debian'
-  package node['mongodb']['package_name'] + '-server' do
-    options node['mongodb']['packager_options']
-    action :install
-    version package_version
-    not_if { node['mongodb']['install_method'] == 'none' }
-  end
+  deb_pkgs = %w(
+    server
+    shell
+    tools
+    mongos
+    ).map { |sfx| "#{node['mongodb']['package_name']}-#{sfx}" }
 
-  package node['mongodb']['package_name'] + '-shell' do
-    options node['mongodb']['packager_options']
-    action :install
-    version package_version
-    not_if { node['mongodb']['install_method'] == 'none' }
-  end
-
-  package node['mongodb']['package_name'] + '-tools' do
-    options node['mongodb']['packager_options']
-    action :install
-    version package_version
-    not_if { node['mongodb']['install_method'] == 'none' }
-  end
-
-  package node['mongodb']['package_name'] + '-mongos' do
+  package deb_pkgs do
     options node['mongodb']['packager_options']
     action :install
     version package_version

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -118,6 +118,37 @@ package node['mongodb']['package_name'] do
   not_if { node['mongodb']['install_method'] == 'none' }
 end
 
+# Change needed so that updates work properly on debian based systems
+if node['platform_family'] == 'debian'
+  package node['mongodb']['package_name'] + '-server' do
+    options node['mongodb']['packager_options']
+    action :install
+    version package_version
+    not_if { node['mongodb']['install_method'] == 'none' }
+  end
+
+  package node['mongodb']['package_name'] + '-shell' do
+    options node['mongodb']['packager_options']
+    action :install
+    version package_version
+    not_if { node['mongodb']['install_method'] == 'none' }
+  end
+
+  package node['mongodb']['package_name'] + '-tools' do
+    options node['mongodb']['packager_options']
+    action :install
+    version package_version
+    not_if { node['mongodb']['install_method'] == 'none' }
+  end
+
+  package node['mongodb']['package_name'] + '-mongos' do
+    options node['mongodb']['packager_options']
+    action :install
+    version package_version
+    not_if { node['mongodb']['install_method'] == 'none' }
+  end
+end
+
 # Create keyFile if specified
 key_file_content = node['mongodb']['key_file_content']
 

--- a/spec/recipes/default_spec.rb
+++ b/spec/recipes/default_spec.rb
@@ -80,11 +80,11 @@ describe 'sc-mongodb::default' do
 
     # mongod_packager_options: pkg install options for mongo per OS
     let(:mongod_packager_options_rhel) do
-      ['--nogpgcheck']
+      '--nogpgcheck'
     end
 
     let(:mongod_packager_options_debian) do
-      ['-o', 'Dpkg::Options::=--force-confold', '--force-yes']
+      '-o Dpkg::Options::="--force-confold" --force-yes'
     end
 
     # mongod_sysconfig_file: sysconfig file location for mongo per OS
@@ -98,11 +98,11 @@ describe 'sc-mongodb::default' do
 
     # mongod_version: RHEL appends a release and OS versions to their versions
     let(:mongod_version_rhel) do
-      '3.2.10-1.el7'
+      '3.2.18-1.el7'
     end
 
     let(:mongod_version_debian) do
-      '3.2.10'
+      '3.2.18'
     end
 
     # All tests in this section run for all OS's
@@ -268,6 +268,36 @@ describe 'sc-mongodb::default' do
       end
     end
 
+    shared_examples_for 'debian based install' do
+      it 'should install "mongodb-org-server" package' do
+        expect(chef_run).to install_package('mongodb-org-server').with(
+          options: mongod_packager_options,
+          version: mongod_version
+        )
+      end
+
+      it 'should install "mongodb-org-shell" package' do
+        expect(chef_run).to install_package('mongodb-org-shell').with(
+          options: mongod_packager_options,
+          version: mongod_version
+        )
+      end
+
+      it 'should install "mongodb-org-tools" package' do
+        expect(chef_run).to install_package('mongodb-org-tools').with(
+          options: mongod_packager_options,
+          version: mongod_version
+        )
+      end
+
+      it 'should install "mongodb-org-mongos" package' do
+        expect(chef_run).to install_package('mongodb-org-mongos').with(
+          options: mongod_packager_options,
+          version: mongod_version
+        )
+      end
+    end
+
     context 'CentOS' do
       let(:chef_run) { ChefSpec::SoloRunner.new(platform: 'centos', version: '7.3.1611').converge(described_recipe) }
 
@@ -306,6 +336,11 @@ describe 'sc-mongodb::default' do
         let(:mongod_version) { mongod_version_debian }
       end
 
+      it_behaves_like 'debian based install' do
+        let(:mongod_packager_options) { mongod_packager_options_debian }
+        let(:mongod_version) { mongod_version_debian }
+      end
+
       it 'should create "mongodb" yum_repository' do
         expect(chef_run).to add_apt_repository('mongodb').with(
           uri: 'http://repo.mongodb.org/apt/debian',
@@ -327,6 +362,11 @@ describe 'sc-mongodb::default' do
         let(:mongod_init_source) { 'debian-mongodb.init.erb' }
         let(:mongod_packager_options) { mongod_packager_options_debian }
         let(:mongod_sysconfig_file) { mongod_sysconfig_file_debian }
+        let(:mongod_version) { mongod_version_debian }
+      end
+
+      it_behaves_like 'debian based install' do
+        let(:mongod_packager_options) { mongod_packager_options_debian }
         let(:mongod_version) { mongod_version_debian }
       end
 
@@ -354,6 +394,11 @@ describe 'sc-mongodb::default' do
         let(:mongod_version) { mongod_version_debian }
       end
 
+      it_behaves_like 'debian based install' do
+        let(:mongod_packager_options) { mongod_packager_options_debian }
+        let(:mongod_version) { mongod_version_debian }
+      end
+
       it 'should create "mongodb" yum_repository' do
         expect(chef_run).to add_apt_repository('mongodb').with(
           uri: 'http://repo.mongodb.org/apt/ubuntu',
@@ -375,6 +420,11 @@ describe 'sc-mongodb::default' do
         let(:mongod_init_source) { 'debian-mongodb.init.erb' }
         let(:mongod_packager_options) { mongod_packager_options_debian }
         let(:mongod_sysconfig_file) { mongod_sysconfig_file_debian }
+        let(:mongod_version) { mongod_version_debian }
+      end
+
+      it_behaves_like 'debian based install' do
+        let(:mongod_packager_options) { mongod_packager_options_debian }
         let(:mongod_version) { mongod_version_debian }
       end
 


### PR DESCRIPTION
This should fix an issue where on debian/ubuntu mongo-org would update but none of the other packages would.