### PR TITLE
Correct attribute usage

### DIFF
--- a/libraries/mongodb.rb
+++ b/libraries/mongodb.rb
@@ -71,7 +71,7 @@ class Chef::ResourceDefinitionList::MongoDB
     end
 
     mongo_host = 'localhost'
-    mongo_port = node['mongodb']['config']['net']['port']
+    mongo_port = node['mongodb']['config']['mongod']['net']['port']
 
     begin
       connection = nil


### PR DESCRIPTION
Just ran into this upon upgrading to 1.0.1 but am not sure how it ever worked. 
```chef (12.21.1)>  mongo_port = node['mongodb']['config']['net']['port']
NoMethodError: undefined method `[]' for nil:NilClass
chef (12.21.1)>  mongo_port = node['mongodb']['config'].keys
 => ["mongod", "mongos"]```