### PR TITLE
Reconverge

### DIFF
--- a/libraries/mongodb.rb
+++ b/libraries/mongodb.rb
@@ -220,7 +220,7 @@ class Chef::ResourceDefinitionList::MongoDB
             force = true
             rs_connection = Mongo::Connection.new(mongo_host, mongo_port, op_timeout: 5, slave_ok: true)
           else
-            rs_connection = Mongo::ReplSetConnection.new(old_members)
+            rs_connection = Mongo::ReplSetConnection.new(old_members.map { |m| m['host'] })
           end
           rs_connection.database_names # check connection
         end

--- a/libraries/mongodb.rb
+++ b/libraries/mongodb.rb
@@ -32,6 +32,15 @@ class Chef::ResourceDefinitionList::MongoDB
   # if node['fqnd'] is a vagrant host, ignore it
   # node['mongodb']['replica_priority'] is required
   #
+  def self.is_cluster_up_to_date?(from_server, expected)
+    cut_down = from_server.map do |s|
+      other = expected.select { |e| s['_id'] == e['_id'] }.first
+      s.select { |k, _v| other.keys.include?(k) }
+    end
+
+    cut_down == expected
+  end
+
   def self.create_replicaset_member(node)
     return {} if node['fqdn'] =~ /\.vagrantup\.com$/
 
@@ -84,13 +93,14 @@ class Chef::ResourceDefinitionList::MongoDB
       return
     end
 
+    Chef::Log.info("#{members.map(&:fqdn).join(', ')}")
     # Want the node originating the connection to be included in the replicaset
     members << node unless members.any? { |m| m.name == node.name }
     members.sort! { |x, y| x.name <=> y.name }
 
     rs_members = members.each_with_index.map do |member, n|
       create_replicaset_member(member).merge('_id' => n)
-    end
+    end.select { |m| m.has_key? 'host' }
 
     Chef::Log.info(
       "Configuring replicaset with members #{members.map { |n| n['hostname'] }.join(', ')}"
@@ -126,9 +136,15 @@ class Chef::ResourceDefinitionList::MongoDB
         abort("Could not connect to database: '#{mongo_host}:#{mongo_port}'")
       end
 
+      rs_member_ips =	members.each_with_index.map do |member, n|		
+        port = member['mongodb']['config']['mongod']['net']['port']		
+        { '_id' => n, 'host' => "#{member['ipaddress']}:#{port}" }		
+      end
+
       # check if both configs are the same
       config = connection['local']['system']['replset'].find_one('_id' => name)
-      if config && config['members'] == rs_members
+      Chef::Log.debug "Current members are #{config['members']} and we expect #{rs_members}"
+      if config && is_cluster_up_to_date?(config['members'], rs_members)
         # config is up-to-date, do nothing
         Chef::Log.info("Replicaset '#{name}' already configured")
       elsif config['_id'] == name && config['members'] == rs_member_ips
@@ -179,14 +195,15 @@ class Chef::ResourceDefinitionList::MongoDB
         new_members = rs_members.dup
         old_ids = old_members.map { |m| m['_id'] }
 
-        old_members_by_host = old_members.group_by { |m| m['host'] }.map_values(&:first)
-        new_members_by_host = new_members.group_by { |m| m['host'] }.map_values(&:first)
+        old_members_by_host = old_members.each_with_object({}) { |m, hash| hash[m['host']] = m  }
+        new_members_by_host = new_members.each_with_object({}) { |m, hash| hash[m['host']] = m  }
 
         ids = (0...256).to_a - old_ids
 
         # use the _id value when present, use a generated one from ids otherwise
         new_members = new_members_by_host.map { |h, m| old_members_by_host.fetch(h, {}).merge(m) }
-                                         .map_values { |m| m.merge('_id' => (m['_id'] || ids.shift)) }
+
+        new_members.map! { |member| member.merge('_id' => (member['_id'] || ids.shift)) }
 
         new_config = config.dup
         new_config['members'] = new_members

--- a/libraries/mongodb.rb
+++ b/libraries/mongodb.rb
@@ -93,7 +93,6 @@ class Chef::ResourceDefinitionList::MongoDB
       return
     end
 
-    Chef::Log.info("#{members.map(&:fqdn).join(', ')}")
     # Want the node originating the connection to be included in the replicaset
     members << node unless members.any? { |m| m.name == node.name }
     members.sort! { |x, y| x.name <=> y.name }


### PR DESCRIPTION
Handle problems where reconverging constantly thinks the cluster has changed. This was happening because the test for a change didn't include default options whereas the server's response had default options, so the configs never matched. Thanks to Andy from the community slack, I came up with some code to compare only the necessary options.

Fixed a problem that appears only in TK where `*.vagrantup.com` hosts are ignored, but still processed later on.

Also re-implemented the `rs_member_ips` that was removed in 6f3f2ca and fixes #179. 

As a result of this, test kitchen replica tests run again:
```
sean~/play/mongodb (reconverge *)$ chef exec kitchen verify replicaset3-centos-73
-----> Starting Kitchen (v1.19.2)
-----> Setting up <replicaset3-centos-73>...
       Finished setting up <replicaset3-centos-73> (0m0.00s).
-----> Verifying <replicaset3-centos-73>...
       Detected alternative framework tests for `inspec`
       Loaded tests from {:path=>".Users.sean.play.mongodb.test.integration.replicaset3.inspec"}

Profile: tests from {:path=>"/Users/sean/play/mongodb/test/integration/replicaset3/inspec"} (tests from {:path=>".Users.sean.play.mongodb.test.integration.replicaset3.inspec"})
Version: (not specified)
Target:  ssh://vagrant@127.0.0.1:2202


  Service mongod
     ✔  should be installed
     ✔  should be enabled
     ✔  should be running
  Bash command
     ✔  mongo --eval "rs.status()" | grep name | wc -l exit_status should eq 0
     ✔  mongo --eval "rs.status()" | grep name | wc -l stdout should match "3"
  Bash command
     ✔  mongo --eval "rs.status()" exit_status should eq 0
     ✔  mongo --eval "rs.status()" stdout should match /.*^connecting to: test\n\{\n\t{1}"set" : "kitchen"\,$.*/
     ✔  mongo --eval "rs.status()" stdout should match /.*^\t{3}"_id" : 0\,\n\t{3}"name" : "mongo1:27017"\,$.*/
     ✔  mongo --eval "rs.status()" stdout should match /.*^\t{3}"_id" : 1\,\n\t{3}"name" : "mongo2:27017"\,$.*/
     ✔  mongo --eval "rs.status()" stdout should match /.*^\t{3}"_id" : 2\,\n\t{3}"name" : "mongo3:27017"\,$.*/

Test Summary: 10 successful, 0 failures, 0 skipped
       Finished verifying <replicaset3-centos-73> (0m0.52s).
```