### PR TITLE
Use pgp keyfiles for debian packages

### DIFF
--- a/recipes/mongodb_org_repo.rb
+++ b/recipes/mongodb_org_repo.rb
@@ -44,8 +44,7 @@ when 'debian'
     uri node['mongodb']['repo']
     distribution "#{node['lsb']['codename']}/mongodb-org/#{package_version_major}"
     components node['platform'] == 'ubuntu' ? ['multiverse'] : ['main']
-    keyserver 'hkp://keyserver.ubuntu.com:80'
-    key package_version_major >= 3.2 ? 'EA312927' : '7F0CEB10'
+    key "https://www.mongodb.org/static/pgp/server-#{package_version_major}.asc"
   end
 when 'amazon', 'fedora', 'rhel'
   # RHEL: https://docs.mongodb.com/manual/tutorial/install-mongodb-on-red-hat/

--- a/spec/recipes/default_spec.rb
+++ b/spec/recipes/default_spec.rb
@@ -311,8 +311,7 @@ describe 'sc-mongodb::default' do
           uri: 'http://repo.mongodb.org/apt/debian',
           distribution: 'wheezy/mongodb-org/3.2',
           components: ['main'],
-          keyserver: 'hkp://keyserver.ubuntu.com:80',
-          key: ['EA312927']
+          key: ['https://www.mongodb.org/static/pgp/server-3.2.asc']
         )
       end
     end
@@ -335,8 +334,7 @@ describe 'sc-mongodb::default' do
           uri: 'http://repo.mongodb.org/apt/debian',
           distribution: 'jessie/mongodb-org/3.2',
           components: ['main'],
-          keyserver: 'hkp://keyserver.ubuntu.com:80',
-          key: ['EA312927']
+          key: ['https://www.mongodb.org/static/pgp/server-3.2.asc']
         )
       end
     end
@@ -359,8 +357,7 @@ describe 'sc-mongodb::default' do
           uri: 'http://repo.mongodb.org/apt/ubuntu',
           distribution: 'trusty/mongodb-org/3.2',
           components: ['multiverse'],
-          keyserver: 'hkp://keyserver.ubuntu.com:80',
-          key: ['EA312927']
+          key: ['https://www.mongodb.org/static/pgp/server-3.2.asc']
         )
       end
     end
@@ -383,8 +380,7 @@ describe 'sc-mongodb::default' do
           uri: 'http://repo.mongodb.org/apt/ubuntu',
           distribution: 'xenial/mongodb-org/3.2',
           components: ['multiverse'],
-          keyserver: 'hkp://keyserver.ubuntu.com:80',
-          key: ['EA312927']
+          key: ['https://www.mongodb.org/static/pgp/server-3.2.asc']
         )
       end
     end


### PR DESCRIPTION
The existing mechanism of specifying and downloading keys from the ubuntu keyserver was unnecessary, and would require a large list of version-> key mappings as MongoDB changes packaging keys with each X.Y release. The keys used are identical to those used for the packages of the other distros , so the same mechanism to specify them can be used. 

This pull request applies that change and allows install of any supported MongoDB version via debian packaging (not accounting for any configuration variances).