### PR TITLE
Update mongo_gem.rb

### DIFF
--- a/recipes/mongo_gem.rb
+++ b/recipes/mongo_gem.rb
@@ -29,7 +29,7 @@ gcc = package 'gcc' do
 end
 gcc.run_action(:install)
 
-sasldev_pkg = if platform_family?('rhel')
+sasldev_pkg = if platform_family?('rhel', 'amazon')
                 'cyrus-sasl-devel'
               else
                 'libsasl2-dev'


### PR DESCRIPTION
Ohai is now detecting platform_family as amazon instead of rhel.

Please take a look here:
https://docs.chef.io/deprecations_ohai_amazon_linux.html