### PR TITLE
Fix derived attribute issue with wrapper cookbooks

### DIFF
--- a/attributes/users.rb
+++ b/attributes/users.rb
@@ -4,8 +4,8 @@ default['mongodb']['authentication']['username'] = 'admin'
 default['mongodb']['authentication']['password'] = 'admin'
 
 default['mongodb']['admin'] = {
-  'username' => default['mongodb']['authentication']['username'],
-  'password' => default['mongodb']['authentication']['password'],
+  'username' => lazy{ node['mongodb']['authentication']['username']},
+  'password' => lazy{ node['mongodb']['authentication']['password']},
   'roles' => %w(userAdminAnyDatabase dbAdminAnyDatabase clusterAdmin),
   'database' => 'admin',
 }

--- a/attributes/users.rb
+++ b/attributes/users.rb
@@ -4,8 +4,8 @@ default['mongodb']['authentication']['username'] = 'admin'
 default['mongodb']['authentication']['password'] = 'admin'
 
 default['mongodb']['admin'] = {
-  'username' => lazy{ node['mongodb']['authentication']['username']},
-  'password' => lazy{ node['mongodb']['authentication']['password']},
+  'username' => lazy { node['mongodb']['authentication']['username'] },
+  'password' => lazy { node['mongodb']['authentication']['password'] },
   'roles' => %w(userAdminAnyDatabase dbAdminAnyDatabase clusterAdmin),
   'database' => 'admin',
 }

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email  'help@sous-chefs.org'
 license           'Apache-2.0'
 description       'Installs and configures mongodb'
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version           '1.0.1'
+version           '1.0.2'
 
 recipe 'sc-mongodb', 'Installs and configures a single node mongodb instance'
 recipe 'sc-mongodb::mongos', 'Installs and configures a mongos which can be used in a sharded setup'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email  'help@sous-chefs.org'
 license           'Apache-2.0'
 description       'Installs and configures mongodb'
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version           '1.0.2'
+version           '1.0.3'
 
 recipe 'sc-mongodb', 'Installs and configures a single node mongodb instance'
 recipe 'sc-mongodb::mongos', 'Installs and configures a mongos which can be used in a sharded setup'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email  'help@sous-chefs.org'
 license           'Apache-2.0'
 description       'Installs and configures mongodb'
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version           '1.0.3'
+version           '1.0.4'
 
 recipe 'sc-mongodb', 'Installs and configures a single node mongodb instance'
 recipe 'sc-mongodb::mongos', 'Installs and configures a mongos which can be used in a sharded setup'

--- a/providers/user.rb
+++ b/providers/user.rb
@@ -240,7 +240,7 @@ def retrieve_db(attempt = 0)
 
   begin
     Mongo::MongoClient.new(
-      @new_resource.connection['host'],
+      '127.0.0.1',
       @new_resource.connection['port'],
       connect_timeout: 15,
       slave_ok: true,

--- a/providers/user.rb
+++ b/providers/user.rb
@@ -243,7 +243,9 @@ def retrieve_db(attempt = 0)
       @new_resource.connection['host'],
       @new_resource.connection['port'],
       connect_timeout: 15,
-      slave_ok: true
+      slave_ok: true,
+      ssl_verify: false,
+      ssl: true
     )
   rescue Mongo::ConnectionFailure
     if attempt < @new_resource.connection['user_management']['connection']['retries']


### PR DESCRIPTION
If you have a wrapper cookbook, a derived attribute issue occurs when trying to converge.

Lazy evaluating the username/password allows this to be set by the wrapper, and doesn't take the default values.
