### PR TITLE
Fix some packages not upgrading in Debian

### DIFF
--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -127,11 +127,13 @@ if node['platform_family'] == 'debian'
     mongos
     ).map { |sfx| "#{node['mongodb']['package_name']}-#{sfx}" }
 
-  package deb_pkgs do
-    options node['mongodb']['packager_options']
-    action :install
-    version package_version
-    not_if { node['mongodb']['install_method'] == 'none' }
+  deb_pkgs.each do |pkg|
+    package pkg do
+      options node['mongodb']['packager_options']
+      action :install
+      version package_version
+      not_if { node['mongodb']['install_method'] == 'none' }
+    end
   end
 end
 


### PR DESCRIPTION
Only mongodb-org and mongodb-org-server are upgrading, the rest are left in current state. This is because when installing multiple packages we need to specify version for each one of them using array notation, otherwise only the first package is being checked against specified version number. In this case it was mongodb-org-server, which is why it was successfully upgraded. Ultimately, it's easier to just run install for each package individually, which is what this change does.

Reference: https://docs.chef.io/resource_package.html#multiple-packages.
