### PR TITLE
mongodb.rb (cluster_up_to_date?): optimize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## unreleased
 
 - Update CI tooling
+* mongodb.rb (cluster_up_to_date?): optimize
 
 ## v2.0.0
 

--- a/libraries/mongodb.rb
+++ b/libraries/mongodb.rb
@@ -35,7 +35,7 @@ class Chef::ResourceDefinitionList::MongoDB
   def self.cluster_up_to_date?(from_server, expected)
     cut_down = from_server.map do |s|
       other = expected.select { |e| s['_id'] == e['_id'] }.first
-      s.select { |k, _v| other.keys.include?(k) }
+      s.select { |k, _v| other.key?(k) }
     end
 
     cut_down == expected


### PR DESCRIPTION
Fixes a rubocop `Performance/InefficientHashSearch: Use #key? instead of #keys.include?` warning

Hopefully makes #222 green