### PR TITLE
MongoDB 8.0 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- MongoDB 8.0 compatibility
+- Ubuntu 22.04 LTS compatibility
+
 ## 5.1.24 - *2024-11-18*
 
 Standardise files with files in sous-chefs/repo-management

--- a/attributes/dbconfig.rb
+++ b/attributes/dbconfig.rb
@@ -18,7 +18,6 @@ if platform_family?('rhel', 'fedora', 'debian')
   default['mongodb']['config']['mongod']['processManagement']['pidFilePath'] = '/var/run/mongodb/mongod.pid'
 end
 
-default['mongodb']['config']['mongod']['storage']['journal']['enabled'] = true
 default['mongodb']['config']['mongod']['storage']['dbPath'] = if platform_family?('rhel', 'fedora')
                                                                 '/var/lib/mongo'
                                                               else

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -53,7 +53,7 @@ default['mongodb']['dbconfig_file']['mongod'] = '/etc/mongod.conf'
 default['mongodb']['dbconfig_file']['mongos'] = '/etc/mongos.conf'
 
 default['mongodb']['package_name'] = 'mongodb'
-default['mongodb']['package_version'] = '7.0.2'
+default['mongodb']['package_version'] = '8.0.5'
 
 default['mongodb']['default_init_name'] = 'mongod'
 default['mongodb']['instance_name']['mongod'] = 'mongod'
@@ -114,6 +114,6 @@ default['mongodb']['key_file_content'] = nil
 # install the mongo and bson_ext ruby gems at compile time to make them globally available
 # TODO: remove bson_ext once mongo gem supports bson >= 2
 default['mongodb']['ruby_gems'] = {
-  mongo: '~> 1.12',
+  mongo: '~> 2.21',
   bson_ext: nil,
 }

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -17,9 +17,7 @@ platforms:
   - name: debian-9
   # - name: debian-10
   # - name: fedora-latest
-  - name: ubuntu-16.04
-  # - name: ubuntu-18.04
-  # - name: ubuntu-20.04
+  - name: ubuntu-22.04
 
 suites:
   - name: default
@@ -96,7 +94,7 @@ suites:
     includes:
       # Only need to test this on one OS since this is
       # purely to test mongo ruby driver code
-      - centos-7
+      - ubuntu-22.04
 
   - name: user_management_v2
     run_list:
@@ -117,7 +115,7 @@ suites:
     includes:
       # Only need to test this on one OS since this is
       # purely to test mongo ruby driver code
-      - centos-7
+      - ubuntu-22.04
 
   - name: user_management_v2_delete
     run_list:
@@ -139,7 +137,7 @@ suites:
     includes:
       # Only need to test this on one OS since this is
       # purely to test mongo ruby driver code
-      - centos-7
+      - ubuntu-22.04
 
   - name: replicaset1
     driver:
@@ -161,7 +159,7 @@ suites:
     includes:
       # Only need to test this on one OS since this is
       # purely to test mongo ruby driver code
-      - centos-7
+      - ubuntu-22.04
 
   - name: replicaset2
     driver:
@@ -183,7 +181,7 @@ suites:
     includes:
       # Only need to test this on one OS since this is
       # purely to test mongo ruby driver code
-      - centos-7
+      - ubuntu-22.04
 
   - name: replicaset3
     driver:
@@ -205,7 +203,7 @@ suites:
     includes:
       # Only need to test this on one OS since this is
       # purely to test mongo ruby driver code
-      - centos-7
+      - ubuntu-22.04
 
   - name: shard1-n1
     driver:
@@ -228,7 +226,7 @@ suites:
     includes:
       # Only need to test this on one OS since this is
       # purely to test mongo ruby driver code
-      - centos-7
+      - ubuntu-22.04
 
   - name: shard1-n2
     driver:
@@ -251,7 +249,7 @@ suites:
     includes:
       # Only need to test this on one OS since this is
       # purely to test mongo ruby driver code
-      - centos-7
+      - ubuntu-22.04
 
   - name: shard1-n3
     driver:
@@ -274,7 +272,7 @@ suites:
     includes:
       # Only need to test this on one OS since this is
       # purely to test mongo ruby driver code
-      - centos-7
+      - ubuntu-22.04
 
   - name: shard-mongos
     driver:
@@ -303,4 +301,4 @@ suites:
     includes:
       # Only need to test this on one OS since this is
       # purely to test mongo ruby driver code
-      - centos-7
+      - ubuntu-22.04

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ description       'Installs and configures mongodb'
 source_url        'https://github.com/sous-chefs/sc-mongodb'
 issues_url        'https://github.com/sous-chefs/sc-mongodb/issues'
 chef_version      '>= 15.3'
-version           '5.1.24'
+version           '5.99.0'
 
 supports 'amazon'
 supports 'centos'

--- a/recipes/mongo_gem.rb
+++ b/recipes/mongo_gem.rb
@@ -21,6 +21,10 @@
 # limitations under the License.
 #
 
+apt_update do
+  compile_time true
+end
+
 # The build-essential cookbook was not running during the compile phase, install gcc explicitly for rhel so native
 # extensions can be installed
 gcc = package 'gcc' do

--- a/test/integration/user_management/inspec/user_management_spec.rb
+++ b/test/integration/user_management/inspec/user_management_spec.rb
@@ -1,10 +1,10 @@
 # @test "requires authentication" {
-#     mongo --eval "db.stats().ok"
+#     mongosh --eval "db.stats().ok"
 #     ! [ $? -eq 1 ]
 # }
 #
 # @test "admin user created" {
-#     mongo admin -u admin -p admin --eval "db.stats().ok"
+#     mongosh admin -u admin -p admin --eval "db.stats().ok"
 #     [ $? -eq 0 ]
 # }
 
@@ -15,15 +15,15 @@ describe service('mongod') do
 end
 
 # admin user created
-describe bash('mongo admin -u admin -p admin --eval "db.stats().ok"') do
+describe bash('mongosh admin -u admin -p admin --eval "db.stats().ok"') do
   its('exit_status') { should eq 0 }
 end
 
-describe bash('mongo --eval "db.stats().ok"') do
+describe bash('mongosh --eval "db.stats().ok"') do
   its('exit_status') { should_not eq 1 }
 end
 
 # kitchen read user created
-describe bash(%(mongo admin -u admin -p admin --eval "db.system.users.find({'_id' : 'admin.kitchen', 'user' : 'kitchen', 'db' : 'admin', 'roles' : [ { 'role' : 'read', 'db' : 'admin' } ]})" | grep _id)) do
+describe bash(%(mongosh admin -u admin -p admin --eval "db.system.users.find({'_id' : 'admin.kitchen', 'user' : 'kitchen', 'db' : 'admin', 'roles' : [ { 'role' : 'read', 'db' : 'admin' } ]})" | grep _id)) do
   its('exit_status') { should eq 0 }
 end

--- a/test/integration/user_management_v2/inspec/user_management_spec.rb
+++ b/test/integration/user_management_v2/inspec/user_management_spec.rb
@@ -1,10 +1,10 @@
 # @test "requires authentication" {
-#     mongo --eval "db.stats().ok"
+#     mongosh --eval "db.stats().ok"
 #     ! [ $? -eq 1 ]
 # }
 #
 # @test "admin user created" {
-#     mongo admin -u admin -p admin --eval "db.stats().ok"
+#     mongosh admin -u admin -p admin --eval "db.stats().ok"
 #     [ $? -eq 0 ]
 # }
 
@@ -15,15 +15,15 @@ describe service('mongod') do
 end
 
 # admin user created
-describe bash('mongo admin -u admin -p admin --eval "db.stats().ok"') do
+describe bash('mongosh admin -u admin -p admin --eval "db.stats().ok"') do
   its('exit_status') { should eq 0 }
 end
 
-describe bash('mongo --eval "db.stats().ok"') do
+describe bash('mongosh --eval "db.stats().ok"') do
   its('exit_status') { should_not eq 1 }
 end
 
 # kitchen read user created
-describe bash(%(mongo admin -u admin -p admin --eval "db.system.users.find({'_id' : 'admin.kitchen', 'user' : 'kitchen', 'db' : 'admin', 'roles' : [ { 'role' : 'read', 'db' : 'admin' } ]})" | grep _id)) do
+describe bash(%(mongosh admin -u admin -p admin --eval "db.system.users.find({'_id' : 'admin.kitchen', 'user' : 'kitchen', 'db' : 'admin', 'roles' : [ { 'role' : 'read', 'db' : 'admin' } ]})" | grep _id)) do
   its('exit_status') { should eq 0 }
 end


### PR DESCRIPTION
- Upgrade Mongo gem to 2.21
- Use Mongosh in tests
- Test on Ubuntu 22.04 LTS
- Remove deprecated `storage.journal.enabled` (from MongoDB 6.1)

# Description

This adds support for MongoDB 8.0 by upgrading the Mongo gem to the latest version. It also removes the deprecated `storage.journal.enabled` option in config (not supported from MongoDB 6). Kitchen environnement upgraded to Ubuntu 22.04 LTS.

## Issues Resolved

List any existing issues this PR resolves

## Check List

- [x] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
